### PR TITLE
Go Modules, Instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+ratago

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ sudo ln -s /usr/local/opt/libxml2/include/libxml2/libxml /usr/local/include/libx
 GO111MODULE=on go get github.com/jbowtie/ratago
 ```
 
+Example Usage
+----
+
+```sh
+ratago -indent transform.xslt data.xml > result.xml
+```
+
 TODO
 ----
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ Currently it should be seen as experimental - it lacks full compliance with the 
 
 The test suite is derived from the test suite used by the libxslt library written by Daniel Veillard. See http://xmlsoft.org/XSLT/ for details on libxslt.
 
+Installation
+----
+
+For MacOS:
+```sh
+# Need pkg-config, see https://stackoverflow.com/a/36794452/700471
+brew install pkg-config 
+# Need libxml2 source, see https://github.com/mitmproxy/mitmproxy/issues/68#issuecomment-120301708
+brew install libxml2
+sudo ln -s /usr/local/opt/libxml2/include/libxml2/libxml /usr/local/include/libxml 
+# Install with Go Modules
+GO111MODULE=on go get github.com/jbowtie/ratago
+```
+
 TODO
 ----
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jbowtie/ratago
+
+go 1.14
+
+require github.com/jbowtie/gokogiri v0.0.0-20190301021639-37f655d3078f

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/jbowtie/gokogiri v0.0.0-20190301021639-37f655d3078f h1:6UIvzqlGM38lOpKP380Wbl0kUyyjutcc7KJUaDM/U4o=
+github.com/jbowtie/gokogiri v0.0.0-20190301021639-37f655d3078f/go.mod h1:C3R3VzPq+DAwilxue7DiV6F2QL1rrQX0L56GyI+sBxM=


### PR DESCRIPTION
- Converting to use Go Modules
- Installation instructions for MacOS
- Example usage